### PR TITLE
prevent posting if ip address is banned

### DIFF
--- a/public/database.php
+++ b/public/database.php
@@ -825,3 +825,20 @@ function update_rebuild_post(array $rebuild_post): bool {
   ');
   return $sth->execute($rebuild_post);
 }
+
+
+// BAN related functions below
+// ------------------------------
+
+function select_ban(string $ip): array|bool {
+  $dbh = get_db_handle();
+  $sth = $dbh->prepare('
+    SELECT expire, reason FROM bans
+    WHERE ip = INET6_ATON(:ip) AND :now < expire
+  ');
+  $sth->execute([
+    'ip' => $ip,
+    'now' => time()
+  ]);
+  return $sth->fetch();
+}

--- a/public/index.php
+++ b/public/index.php
@@ -709,6 +709,13 @@ function handle_postform(Request $request, Response $response, array $args, stri
     }
   }
 
+  // check if ip address has been banned
+  $ban = select_ban($user_ip);
+  if ($ban) {
+    $ban_expires = strftime(MB_DATEFORMAT, $ban['expire']);
+    throw new AppException('index', 'route', "this ip address has been banned for reason: {$ban['reason']}. The ban will expire on {$ban_expires}", SC_FORBIDDEN);
+  }
+
   // get thread if replying
   $thread_id = null;
   if (isset($args['thread_id'])) {


### PR DESCRIPTION
Basic functionality to prevent posting if user's IP address is in the 'bans' table. Returns 403 Forbidden in case matching IP is found  and ban expiry date has not yet been passed. 

Very limited testing done from the performance perspective. I ran this locally in dev mode with approx. 0.9 million rows in the bans table, with no noticeable effects. Raw SQL query seems to take less than 20 milliseconds. 
